### PR TITLE
Mobile: portrait forest-canyon homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,12 +170,6 @@
      The hard outer cut tucks under the 14px frame border. */
   .edge-l{left:0}
   .edge-r{right:0}
-  /* AURORA ONLY: every sheet is marble, so there is no empty clearing for the column edge to
-     meet — column and centre show different slices of the marble and butt on a pattern-jump.
-     Aurora is the sanctioned gradient rule-breaker (RULES.md exception 2), so here, and only
-     here, feather the inner edge to dissolve that seam. The flat palettes stay fully opaque. */
-  body.pal-aurora .edge-l{-webkit-mask-image:linear-gradient(90deg,#000 58%,transparent);mask-image:linear-gradient(90deg,#000 58%,transparent)}
-  body.pal-aurora .edge-r{-webkit-mask-image:linear-gradient(270deg,#000 58%,transparent);mask-image:linear-gradient(270deg,#000 58%,transparent)}
   @media (max-width:760px){
     .edge{display:block;width:25vw}
     .intro,.content{padding-left:26vw;padding-right:26vw}
@@ -771,7 +765,7 @@
   // trees, all rooted ON the bank crest so no trunk floats. (Rolls the most — it is
   // the furthest, softest ground.)
   const bushKinds=[['ponga',210,300],['nikau',240,330],['pohutukawa',185,255],['cabbage',180,245]];
-  // On mobile the central footer mound is confined to the clearing (x420..780, >MARGIN_W) so it
+  // On mobile the central footer mound is confined to the clearing (x420..780, inside CLEAR_L) so it
   // never appears in the side-frame columns (which would split one hill across two views).
   // On mobile the side columns cover the outer ~25vw each (≈ central-x 415-507 and 692-785), so
   // the central footer must stay NARROW and inside that clear zone, or the columns' hard inner
@@ -879,16 +873,16 @@
    if(q.has('faronly')){ for(const k of ['sky','haze','deep','mid','bush','margin','fore']){ const s=$('l-'+k); if(s) s.innerHTML=''; } }
    if(q.has('faronly')||q.has('fartint')) document.documentElement.style.setProperty('--far','#e0322f');}
 
-  // MOBILE FRAMING — reuse the desktop layers as side frames. The slice crops the scene to
-  // its central clearing, so the rich margin foliage (bush, tree ferns, the kiwi) is off-frame
-  // and the sides read empty. Rather than draw new mobile-only bush, CLONE the built layer
-  // SVGs into two thin edge columns and show the INNER EDGE of each forest margin in them:
-  // each clone gets a narrow viewBox window that ENDS just inside the central clearing
-  // ([0..MARGIN_W] on the left, [1200-MARGIN_W..1200] on the right), anchored so the clearing
-  // side faces inward. So the visible inner boundary is the forest's own ragged silhouette
-  // tapering into open ground — no blur — while the dense outer cut hides under the frame
-  // border. Re-run on palette change so the clones track the live colours.
-  const MARGIN_W=388;                                      // viewBox units of margin shown per side (ends just inside the clearing ~378)
+  // MOBILE FRAMING — reuse the desktop layers as side frames. The centre stage is the full
+  // 1200x800 scene under "xMidYMid slice" (cover): on a portrait phone it over-zooms to cover
+  // the height, cropping width hard to the central clearing (~viewBox 415..785), so the rich
+  // margin foliage is off-frame and the sides read empty. Rather than draw new mobile-only
+  // bush, CLONE the built layer SVGs into two thin edge columns — but the columns must read as
+  // the SAME diorama, not pasted-on panels. So each column shows the forest margin sitting just
+  // OUTSIDE the centre crop, at the SAME scale (px-per-viewBox-unit) as the centre, butted
+  // against the crop edge: the silhouette, the air-gap shadows and the ground all continue at
+  // one scale into the clearing where the text reads. No compression, no feather. Recomputed on
+  // a real width change (orientation) and on palette change so the clones track the live scene.
   // the clones must parallax in lockstep with the main scene, so each carries its source
   // layer's depth; `edgeLayers` is transformed alongside `layers` in the rAF loop, and
   // `lastAmp` lets a fresh clone (palette/resize re-clone) snap to the current scroll offset.
@@ -897,6 +891,12 @@
     if(!SCENE_BUILT || !matchMedia('(max-width:760px)').matches) return;
     const L=$('edge-l'), R=$('edge-r'); if(!L||!R) return;
     L.innerHTML=''; R.innerHTML=''; edgeLayers=[];
+    // Reconstruct the centre stage's cover crop for THIS viewport so the columns can continue it.
+    const W=innerWidth, H=innerHeight;
+    const sc=Math.max(W/1200, H/800);          // cover scale (px per viewBox unit) — height-led on a phone
+    const xL=600-W/(2*sc), xR=600+W/(2*sc);    // centre crop's left / right viewBox edges
+    const yT=400-H/(2*sc), visH=H/sc;          // centre crop's vertical window (columns share it, full-height)
+    const colU=0.25*W/sc;                      // viewBox units a 25vw column spans at the centre's scale
     const srcs=document.querySelectorAll('.stage .layer svg'), N=srcs.length;
     srcs.forEach((orig,j)=>{
       const depth=parseFloat(orig.parentElement.dataset.depth);
@@ -908,12 +908,14 @@
         d.removeAttribute('id');                            // keep getElementById pointing at the originals
         d.dataset.depth=depth; d.style.willChange='transform'; d.style.transitionDelay=delay;
       }
-      // LEFT: window [0..MARGIN_W], its INNER side (x=MARGIN_W, into the clearing) anchored inward.
-      dl.setAttribute('viewBox',`0 0 ${MARGIN_W} 800`);
-      dl.setAttribute('preserveAspectRatio','xMaxYMid slice');
-      // RIGHT: window [1200-MARGIN_W..1200], its INNER side (x=1200-MARGIN_W) anchored inward.
-      dr.setAttribute('viewBox',`${1200-MARGIN_W} 0 ${MARGIN_W} 800`);
-      dr.setAttribute('preserveAspectRatio','xMinYMid slice');
+      // LEFT: the colU-wide margin window ending exactly at the centre crop's left edge (xL),
+      // same vertical window — so it butts the centre seamlessly at the column's inner edge.
+      dl.setAttribute('viewBox',`${(xL-colU).toFixed(2)} ${yT.toFixed(2)} ${colU.toFixed(2)} ${visH.toFixed(2)}`);
+      // RIGHT: the colU-wide margin window starting exactly at the centre crop's right edge (xR).
+      dr.setAttribute('viewBox',`${xR.toFixed(2)} ${yT.toFixed(2)} ${colU.toFixed(2)} ${visH.toFixed(2)}`);
+      // viewBox aspect == column pixel aspect by construction, so slice == meet here (exact fill).
+      dl.setAttribute('preserveAspectRatio','xMidYMid slice');
+      dr.setAttribute('preserveAspectRatio','xMidYMid slice');
       L.appendChild(dl); R.appendChild(dr);
       edgeLayers.push({el:dl,depth},{el:dr,depth});
     });

--- a/index.html
+++ b/index.html
@@ -940,7 +940,11 @@
           lastY=cy; lastX=x;
           const t=Math.max(0,Math.min(1,(cy-edgeY)/(FLOOR-edgeY)));   // 0 near top → 1 at the floor
           const [kn,a,b]=pick(); let h=(a+(b-a)*r())*(0.76+0.24*t);   // bolder toward the floor, still tall up top
-          const px=mclampX(x,h,kn,side), by=crest(px)+10;             // ROOT on the bank at the clamped x → never floats
+          let px=mclampX(x,h,kn,side), bury=12;
+          // tuck harakeke/flax further toward the frame edge and bury it deep, so its flat cut
+          // base hides under the ground / off-frame and only the blades read.
+          if(kn==='flax'){ px=side<0?Math.max(edge,px-34):Math.min(edge,px+34); bury=52; }
+          const by=crest(px)+bury;                                    // ROOT on the bank at the clamped x → never floats
           h=Math.min(h,(by-TOP_M)/(STAMP[kn].crown||1.1));            // cap height so crowns never clip the frame top
           items.push({x:px,by,h,kn,sd:(seed^(i*61))|0});
         }
@@ -956,8 +960,10 @@
     };
 
     // back→front: smaller + reaching closer to the centre behind, bolder + further out in front.
-    const kFar=[['ponga',150,250],['nikau',160,270],['pohutukawa',140,236],['cabbage',146,244],['flax',120,200],['toetoe',124,204],['frond',120,196]];
-    const kMid=[['ponga',230,360],['nikau',248,392],['pohutukawa',210,340],['cabbage',220,352],['flax',186,300],['frond',182,292]];
+    // NOTE: no lone `frond` in the airy far/mid layers — a single frond against the light reads as
+    // a floating leaf (it has no clustered base). Fronds live only in the dense foreground thicket.
+    const kFar=[['ponga',150,250],['nikau',160,270],['pohutukawa',140,236],['cabbage',146,244],['flax',120,200],['toetoe',124,204]];
+    const kMid=[['ponga',230,360],['nikau',248,392],['pohutukawa',210,340],['cabbage',220,352],['flax',186,300]];
     const kBush=[['ponga',330,500],['nikau',380,560],['pohutukawa',300,452],['cabbage',312,470]];
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
     const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344]];
@@ -977,18 +983,20 @@
      mfore += `<path fill="var(--fore)" d="${md} L920,${MOB_H+8} Z"/>`;
      // foreground thicket kept to the centre-RIGHT, leaving a clear pocket for the kiwi on the left.
      const footK=[['frond',150,220],['flax',150,214],['toetoe',150,206]], fr=rng(sub(14)), fpick=kindPicker(fr,footK);
-     for(const fx of [528,612,694,778]){ if(fr()<0.85){ const [kn,a,b]=fpick(), h=a+(b-a)*fr();
-       mfore += STAMP[kn].draw(fx+(fr()-0.5)*24, mcY(fx)+6, h, 'var(--fore)', (sub(14)^(fx*7))|0, fx<600?-1:1); } }
+     for(const fx of [528,612,694,778]){ if(fr()<0.85){ const [kn,a,b]=fpick(), h=a+(b-a)*fr(), jx=fx+(fr()-0.5)*24;
+       // read the mound height at the JITTERED x (not fx) so the plant sits on the slope, never floats
+       mfore += STAMP[kn].draw(jx, mcY(jx)+(kn==='flax'?40:6), h, 'var(--fore)', (sub(14)^(fx*7))|0, fx<600?-1:1); } }
      // FOCAL KIWI — on the low mound just inside the clearing, head & bill facing right into OPEN
      // deep (clear pocket to ~520), feet buried in the mound; its silhouette reads against the light.
      const kS=2.2, kx=372; mfore += kiwi(kx, mcY(kx)-47*kS, kS, 'var(--fore)');}
     // two pīwakawaka on a twig on the RIGHT, set where bush/margin/fore have dived away so they
     // read against the lighter far/deep backdrop; the twig roots to the base (connected sheet).
-    {const ftS=1.9, ftL=876, ftR=920, ftCy=FLOOR-374;
-     mfore += limb([[ftR+30,ftCy+34],[ftR+26,ftCy+150],[ftR+20,ftCy+320],[ftR+16,MOB_H+8]],[2,5,9,13],'var(--fore)',true)
-            + limb([[ftL-10,ftCy+26],[ftL+34,ftCy+52],[ftL+88,ftCy+80],[ftR+30,ftCy+34]],[1,3.2,5.5,7],'var(--fore)',true);
+    // two pīwakawaka spaced along a level twig (no longer bills-touching), the twig rooted down
+    // to the base (connected sheet); set against the lighter far/deep so the dark birds read.
+    {const ftS=1.9, ftL=846, ftR=952, ftCy=FLOOR-372;
+     mfore += limb([[ftL-22,ftCy+34],[ftL+50,ftCy+44],[ftR+2,ftCy+40],[ftR+26,ftCy+200],[ftR+18,MOB_H+8]],[1.3,3.4,5.5,9,13],'var(--fore)',true);
      mfore += fantail(ftL, ftCy, ftS, 'var(--fore)')
-            + `<g transform="translate(${(2*ftR).toFixed(1)} 0) scale(-1 1)">`+fantail(ftR, ftCy+6, ftS, 'var(--fore)')+`</g>`;}
+            + `<g transform="translate(${(2*ftR).toFixed(1)} 0) scale(-1 1)">`+fantail(ftR, ftCy+4, ftS, 'var(--fore)')+`</g>`;}
     $('l-fore').innerHTML=mfore;
   }
 

--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
   // recoloured live via CSS vars) and the aurora masked-marble form. Originals are cached
   // so switching back is instant.
   const AURORA_ORIG={};
-  let AURORA_MASKED=false, SCENE_BUILT=false;
+  let AURORA_MASKED=false, SCENE_BUILT=false, CANYON=false;
   function auroraMaskify(on){
     if(!SCENE_BUILT || on===AURORA_MASKED) return;
     if(on){
@@ -873,6 +873,64 @@
    if(q.has('faronly')){ for(const k of ['sky','haze','deep','mid','bush','margin','fore']){ const s=$('l-'+k); if(s) s.innerHTML=''; } }
    if(q.has('faronly')||q.has('fartint')) document.documentElement.style.setProperty('--far','#e0322f');}
 
+  // ===== MOBILE — PORTRAIT FOREST CANYON (Tier 2, iteration 1) ===============
+  // Desktop keeps its wide 1200x800 cover scene (built above) UNTOUCHED. A portrait phone can
+  // only crop that to the empty central clearing or shrink it to a thin strip — never lush — so
+  // on mobile we OVERWRITE the layers with a portrait-native build: dense foliage WALLS up both
+  // margins, a clear central column for the text, sky + moon above, foreground and the focal
+  // kiwi at the base. Same paper-cut stamps, arranged TALL instead of wide.
+  if(MB){
+    CANYON=true;                              // keep the (now superseded) side-frame cloner out
+    const MOB_H=1800;                         // tall viewBox: cover keeps foliage large AND full-height,
+                                              // while the 444u central column stays ~200px wide for text.
+    for(const k of ['sky','haze','deep','far','mid','bush','margin','fore'])
+      $('l-'+k).setAttribute('viewBox',`0 0 1200 ${MOB_H}`);
+
+    // SKY — flat card over the whole tall frame; a moon hole high in the clear centre, birds below.
+    let cut=`<rect width="1200" height="${MOB_H}" fill="#fff"/><circle cx="620" cy="205" r="50" fill="#000"/>`;
+    {const r=rng(sub(20));
+     for(const [bx,by,bw] of [[500,360,24],[572,326,28],[648,300,30],[726,330,25],[610,420,18]])
+       cut+=birdHole(bx+(r()-0.5)*26, by+(r()-0.5)*16, bw, (r()-0.5)*0.5);}
+    $('l-sky').innerHTML=
+      `<defs><mask id="cut-sky-m" maskUnits="userSpaceOnUse" x="0" y="0" width="1200" height="${MOB_H}">${cut}</mask></defs>`+
+      `<rect width="1200" height="${MOB_H}" fill="var(--sky)" mask="url(#cut-sky-m)"/>`;
+    $('l-haze').innerHTML=''; $('l-deep').innerHTML='';
+
+    // ONE foliage wall up a margin: a thin ragged backing bank hugging the frame edge, then
+    // plants stacked bottom→top and clamped clear of the central text column. side -1=L, +1=R.
+    const mwall=(side,reach,kinds,fill,seed,gap)=>{
+      const r=rng(seed), pick=kindPicker(r,kinds), nz=noise(r,reach*0.16);
+      const edge=side<0?0:1200, inX=y=>edge-side*(reach*0.30+nz(y/MOB_H));
+      const N=48; let d=`M${edge},-4`;
+      for(let i=0;i<=N;i++){const y=MOB_H*i/N; d+=` L${inX(y).toFixed(1)},${y.toFixed(1)}`;}
+      d+=` L${edge},${MOB_H+4} Z`;
+      let g=`<path fill="${fill}" d="${d}"/>`, items=[];
+      for(let by=MOB_H+gap*0.4; by>-gap; by-=gap*(0.78+0.46*r())){
+        const [kn,a,b]=pick(), h=a+(b-a)*r();
+        const x=clampX(edge-side*(reach*(0.16+0.5*r())), h, kn, side);
+        items.push({x,by,h,kn,sd:(seed^((by*7)|0))|0});
+      }
+      for(const it of items) g+=STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,side);
+      return g;
+    };
+
+    // back→front: smaller + further in behind, bolder + at the edge in front (vertical aerial depth)
+    const wFar   =[['ponga',70,118],['nikau',74,122],['pohutukawa',66,108],['flax',56,94],['toetoe',58,96]];
+    const wMid   =[['ponga',108,168],['nikau',116,180],['pohutukawa',98,158],['cabbage',102,164],['flax',86,136]];
+    const wBush  =[['ponga',196,284],['nikau',226,316],['pohutukawa',176,246],['cabbage',172,236]];
+    const wMargin=[['ponga',148,202],['cabbage',148,202],['flax',118,168],['toetoe',118,162]];
+    const wFore  =[['frond',128,186],['flax',114,160],['toetoe',114,154],['grass',62,95]];
+
+    $('l-far').innerHTML    = mwall(-1,470,wFar,   'var(--far)',   sub(8), 150)+mwall(+1,470,wFar,   'var(--far)',   sub(9), 150);
+    $('l-mid').innerHTML    = mwall(-1,420,wMid,   'var(--mid)',   sub(10),210)+mwall(+1,420,wMid,   'var(--mid)',   sub(11),210);
+    $('l-bush').innerHTML   = mwall(-1,372,wBush,  'var(--bush)',  sub(1), 300)+mwall(+1,372,wBush,  'var(--bush)',  sub(2), 300);
+    $('l-margin').innerHTML = mwall(-1,332,wMargin,'var(--margin)',sub(3), 250)+mwall(+1,332,wMargin,'var(--margin)',sub(4), 250);
+    let mfore = mwall(-1,300,wFore,'var(--fore)',sub(5),300)+mwall(+1,300,wFore,'var(--fore)',sub(6),300);
+    // FOCAL KIWI at the base of the left wall, facing right into the clearing (as on desktop).
+    const kS=1.45; mfore += kiwi(150, MOB_H-96, kS, 'var(--fore)');
+    $('l-fore').innerHTML=mfore;
+  }
+
   // MOBILE FRAMING — reuse the desktop layers as side frames. The centre stage is the full
   // 1200x800 scene under "xMidYMid slice" (cover): on a portrait phone it over-zooms to cover
   // the height, cropping width hard to the central clearing (~viewBox 415..785), so the rich
@@ -889,6 +947,7 @@
   let edgeLayers=[], lastAmp=0;
   function refreshEdges(){
     if(!SCENE_BUILT || !matchMedia('(max-width:760px)').matches) return;
+    if(CANYON) return;                         // Tier 2 portrait canyon replaces the side-frame clones
     const L=$('edge-l'), R=$('edge-r'); if(!L||!R) return;
     L.innerHTML=''; R.innerHTML=''; edgeLayers=[];
     // Reconstruct the centre stage's cover crop for THIS viewport so the columns can continue it.

--- a/index.html
+++ b/index.html
@@ -961,6 +961,13 @@
      for(const fx of [372,452,600,748,828]){ if(fr()<0.9){ const [kn,a,b]=fpick(), h=a+(b-a)*fr();
        mfore += STAMP[kn].draw(fx+(fr()-0.5)*30, mcY(fx)+6, h, 'var(--fore)', (sub(14)^(fx*7))|0, fx<600?-1:1); } }}
     const kS=2.3; mfore += kiwi(296, FLOOR-58, kS, 'var(--fore)');
+    // two pīwakawaka perched together on a foreground twig on the RIGHT, facing each other
+    // (the right bird is the same stamp mirrored about its own centre) — echoing desktop.
+    mfore += limb([[968,FLOOR-150],[952,FLOOR-84],[946,FLOOR-16],[946,MOB_H+8]],[2,5,9,12],'var(--fore)',true);
+    {const ftS=1.85, ftL=872, ftR=934, ftCy=FLOOR-172;
+     mfore += limb([[ftL-12,ftCy+30],[ftL+30,ftCy+58],[ftL+86,ftCy+86],[ftR+44,ftCy+150]],[1.2,3.5,6,9],'var(--fore)',true);
+     mfore += fantail(ftL, ftCy, ftS, 'var(--fore)')
+            + `<g transform="translate(${(2*ftR).toFixed(1)} 0) scale(-1 1)">`+fantail(ftR, ftCy+6, ftS, 'var(--fore)')+`</g>`;}
     $('l-fore').innerHTML=mfore;
   }
 

--- a/index.html
+++ b/index.html
@@ -919,7 +919,7 @@
     // WIDENED central clearing for mobile — more breathing room for the text than desktop's
     // 378..822, plus a little extra clamp pad so a stray crown tip never reaches the copy. Flax
     // gets extra room because it leans inward (below), so its tilted fronds still clear the text.
-    const MCL=362, MCR=838, TOP_M=34;
+    const MCL=344, MCR=856, TOP_M=34;
     const mclampX=(x,h,kn,side)=>{ const w=((STAMP[kn].cw||0.5)+(kn==='flax'?0.18:kn==='nikau'?0.18:0))*h+8;
       return side<0 ? Math.min(x,MCL-w) : Math.max(x,MCR+w); };
 
@@ -978,7 +978,7 @@
 
     // vstep spaces the big trees apart — eased a touch so the far→margin walls don't crowd with
     // large trunks (footer density comes from the small-treeline mounds below instead).
-    $('l-far').innerHTML    = tallBay(-1,360,182,kFar,'var(--far)',sub(8),118,1.5)   + tallBay(+1,840,182,kFar,'var(--far)',sub(9),118,1.5);
+    $('l-far').innerHTML    = tallBay(-1,344,182,kFar,'var(--far)',sub(8),118,1.5)   + tallBay(+1,856,182,kFar,'var(--far)',sub(9),118,1.5);
     $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),164,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),164,1.5);
     $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),272,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),272,1.6);
     $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),248,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),248,1.7);

--- a/index.html
+++ b/index.html
@@ -881,53 +881,86 @@
   // kiwi at the base. Same paper-cut stamps, arranged TALL instead of wide.
   if(MB){
     CANYON=true;                              // keep the (now superseded) side-frame cloner out
-    const MOB_H=1800;                         // tall viewBox: cover keeps foliage large AND full-height,
-                                              // while the 444u central column stays ~200px wide for text.
+    const MOB_H=1800, FLOOR=MOB_H-24;         // tall portrait viewBox; valley floor just shy of the base
     for(const k of ['sky','haze','deep','far','mid','bush','margin','fore'])
       $('l-'+k).setAttribute('viewBox',`0 0 1200 ${MOB_H}`);
 
-    // SKY — flat card over the whole tall frame; a moon hole high in the clear centre, birds below.
-    let cut=`<rect width="1200" height="${MOB_H}" fill="#fff"/><circle cx="620" cy="205" r="50" fill="#000"/>`;
+    // SKY strip + moon hole + a drifting skein, all kept high & clear of the text (RULES §3,§4).
+    let cut=`<rect width="1200" height="${MOB_H}" fill="#fff"/><circle cx="600" cy="140" r="48" fill="#000"/>`;
     {const r=rng(sub(20));
-     for(const [bx,by,bw] of [[500,360,24],[572,326,28],[648,300,30],[726,330,25],[610,420,18]])
-       cut+=birdHole(bx+(r()-0.5)*26, by+(r()-0.5)*16, bw, (r()-0.5)*0.5);}
+     for(const [bx,by,bw] of [[486,206,22],[556,180,26],[636,168,30],[716,184,24],[600,232,17]])
+       cut+=birdHole(bx+(r()-0.5)*24, by+(r()-0.5)*14, bw, (r()-0.5)*0.5);}
     $('l-sky').innerHTML=
       `<defs><mask id="cut-sky-m" maskUnits="userSpaceOnUse" x="0" y="0" width="1200" height="${MOB_H}">${cut}</mask></defs>`+
       `<rect width="1200" height="${MOB_H}" fill="var(--sky)" mask="url(#cut-sky-m)"/>`;
-    $('l-haze').innerHTML=''; $('l-deep').innerHTML='';
 
-    // ONE foliage wall up a margin: a thin ragged backing bank hugging the frame edge, then
-    // plants stacked bottom→top and clamped clear of the central text column. side -1=L, +1=R.
-    const mwall=(side,reach,kinds,fill,seed,gap)=>{
-      const r=rng(seed), pick=kindPicker(r,kinds), nz=noise(r,reach*0.16);
-      const edge=side<0?0:1200, inX=y=>edge-side*(reach*0.30+nz(y/MOB_H));
-      const N=48; let d=`M${edge},-4`;
-      for(let i=0;i<=N;i++){const y=MOB_H*i/N; d+=` L${inX(y).toFixed(1)},${y.toFixed(1)}`;}
-      d+=` L${edge},${MOB_H+4} Z`;
-      let g=`<path fill="${fill}" d="${d}"/>`, items=[];
-      for(let by=MOB_H+gap*0.4; by>-gap; by-=gap*(0.78+0.46*r())){
-        const [kn,a,b]=pick(), h=a+(b-a)*r();
-        const x=clampX(edge-side*(reach*(0.16+0.5*r())), h, kn, side);
-        items.push({x,by,h,kn,sd:(seed^((by*7)|0))|0});
+    // FULL-WIDTH back bands (as on desktop): a pale haze treeline under the sky strip, then the
+    // DEEP card — the flat backdrop the page text reads on. Both fill DOWN to the base, so the
+    // central column reveals deep at every scroll position (the nearer margins dive away from it).
+    const tallBand=(baseY,kinds,n,fill,seed,roll)=>{
+      const r=rng(seed), nz=noise(r,roll), crest=x=>baseY+nz(x/1200);
+      let d=`M0,${MOB_H+8} L0,${crest(0).toFixed(1)}`; const N=92;
+      for(let i=1;i<=N;i++){const x=1200*i/N; d+=` L${x.toFixed(1)},${crest(x).toFixed(1)}`;}
+      let html=`<path fill="${fill}" d="${d} L1200,${MOB_H+8} Z"/>`;
+      const slotW=1200/n, pick=kindPicker(r,kinds); let items=[];
+      for(let i=0;i<n;i++){const x=slotW*(i+0.5)+(r()-0.5)*slotW*0.6, [kn,a,b]=pick(), by=crest(x)+6, h=a+(b-a)*r();
+        items.push({x,by,h,kn,sd:(seed^(i*97+3))|0});}
+      items.sort((p,q)=>q.h-p.h);
+      html+=items.map(it=>STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,it.x<600?-1:1)).join('');
+      return html;
+    };
+    $('l-haze').innerHTML=tallBand(250,[['pohutukawa',22,34],['cabbage',24,38],['ponga',24,38],['nikau',26,40],['flax',18,30],['grass',11,18]],50,'var(--haze)',sub(21),12);
+    $('l-deep').innerHTML=tallBand(322,[['pohutukawa',30,48],['cabbage',32,50],['ponga',32,50],['nikau',34,52],['flax',24,40],['grass',15,25]],40,'var(--deep)',sub(19),14);
+
+    // a TALL hillside bank up one margin: ground rises from the centre-floor to the frame edge,
+    // plants rooted ON the crest with their feet buried in the bank — one connected sheet, never
+    // floating (RULES §6). The crest dives to the floor SHORT of the clearing, so the central
+    // column keeps revealing the flat deep card and nothing dark crosses the text (RULES §7b).
+    const tallBay=(side,innerX,edgeY,kinds,fill,seed,vstep,divePow)=>{
+      const r=rng(seed), edge=side<0?0:1200, span=innerX-edge;
+      const crest=makeCrest(edge,innerX,edgeY,FLOOR,r,34,divePow);
+      const N=80; let d=`M${edge},${MOB_H+8} L${edge.toFixed(1)},${crest(edge).toFixed(1)}`;
+      for(let i=1;i<=N;i++){const x=edge+span*(i/N); d+=` L${x.toFixed(1)},${crest(x).toFixed(1)}`;}
+      d+=` L${innerX.toFixed(1)},${MOB_H+8} Z`;
+      let g=`<path fill="${fill}" d="${d}"/>`, items=[], pick=kindPicker(r,kinds);
+      let lastY=crest(edge)+vstep*3;
+      for(let i=0;i<=240;i++){
+        const x=edge+span*(i/240), cy=crest(x);
+        if(Math.abs(cy-lastY)>=vstep*(0.78+0.44*r())){
+          lastY=cy;
+          const t=Math.max(0,Math.min(1,(cy-edgeY)/(FLOOR-edgeY)));   // 0 near top → 1 at the floor
+          const [kn,a,b]=pick(); const h=(a+(b-a)*r())*(0.76+0.24*t); // bolder toward the floor, still tall up top
+          items.push({x:clampX(x,h,kn,side),by:cy+10,h,kn,sd:(seed^(i*61))|0});
+        }
       }
+      items.sort((p,q)=>q.h-p.h);
       for(const it of items) g+=STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,side);
       return g;
     };
 
-    // back→front: smaller + further in behind, bolder + at the edge in front (vertical aerial depth)
-    const wFar   =[['ponga',70,118],['nikau',74,122],['pohutukawa',66,108],['flax',56,94],['toetoe',58,96]];
-    const wMid   =[['ponga',108,168],['nikau',116,180],['pohutukawa',98,158],['cabbage',102,164],['flax',86,136]];
-    const wBush  =[['ponga',196,284],['nikau',226,316],['pohutukawa',176,246],['cabbage',172,236]];
-    const wMargin=[['ponga',148,202],['cabbage',148,202],['flax',118,168],['toetoe',118,162]];
-    const wFore  =[['frond',128,186],['flax',114,160],['toetoe',114,154],['grass',62,95]];
+    // back→front: smaller + reaching closer to the centre behind, bolder + further out in front.
+    const kFar=[['ponga',150,250],['nikau',160,270],['pohutukawa',140,236],['cabbage',146,244],['flax',120,200],['toetoe',124,204],['frond',120,196]];
+    const kMid=[['ponga',230,360],['nikau',248,392],['pohutukawa',210,340],['cabbage',220,352],['flax',186,300],['frond',182,292]];
+    const kBush=[['ponga',330,500],['nikau',380,560],['pohutukawa',300,452],['cabbage',312,470]];
+    const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
+    const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344],['grass',150,232]];
 
-    $('l-far').innerHTML    = mwall(-1,470,wFar,   'var(--far)',   sub(8), 150)+mwall(+1,470,wFar,   'var(--far)',   sub(9), 150);
-    $('l-mid').innerHTML    = mwall(-1,420,wMid,   'var(--mid)',   sub(10),210)+mwall(+1,420,wMid,   'var(--mid)',   sub(11),210);
-    $('l-bush').innerHTML   = mwall(-1,372,wBush,  'var(--bush)',  sub(1), 300)+mwall(+1,372,wBush,  'var(--bush)',  sub(2), 300);
-    $('l-margin').innerHTML = mwall(-1,332,wMargin,'var(--margin)',sub(3), 250)+mwall(+1,332,wMargin,'var(--margin)',sub(4), 250);
-    let mfore = mwall(-1,300,wFore,'var(--fore)',sub(5),300)+mwall(+1,300,wFore,'var(--fore)',sub(6),300);
-    // FOCAL KIWI at the base of the left wall, facing right into the clearing (as on desktop).
-    const kS=1.45; mfore += kiwi(150, MOB_H-96, kS, 'var(--fore)');
+    $('l-far').innerHTML    = tallBay(-1,372,210,kFar,'var(--far)',sub(8),130,1.0)   + tallBay(+1,828,210,kFar,'var(--far)',sub(9),130,1.0);
+    $('l-mid').innerHTML    = tallBay(-1,338,240,kMid,'var(--mid)',sub(10),195,1.0)  + tallBay(+1,862,240,kMid,'var(--mid)',sub(11),195,1.0);
+    $('l-bush').innerHTML   = tallBay(-1,304,280,kBush,'var(--bush)',sub(1),290,1.0) + tallBay(+1,896,280,kBush,'var(--bush)',sub(2),290,1.0);
+    $('l-margin').innerHTML = tallBay(-1,266,330,kMargin,'var(--margin)',sub(3),235,1.0)+tallBay(+1,934,330,kMargin,'var(--margin)',sub(4),235,1.0);
+    let mfore = tallBay(-1,228,390,kFore,'var(--fore)',sub(5),285,1.0)+tallBay(+1,972,390,kFore,'var(--fore)',sub(6),285,1.0);
+
+    // valley floor: a low central mound closing the foot of the clearing (connected to the base),
+    // a small foreground thicket on it, then the focal kiwi facing right into the clearing (as desktop).
+    {const r=rng(sub(13)), amp=140, mcY=x=>FLOOR-amp*Math.exp(-Math.pow((x-600)/250,2))+noise(r,18)((x-300)/600)*0.6;
+     let md=`M280,${MOB_H+8}`;
+     for(let i=0;i<=44;i++){const x=280+640*i/44; md+=` L${x.toFixed(1)},${mcY(x).toFixed(1)}`;}
+     mfore += `<path fill="var(--fore)" d="${md} L920,${MOB_H+8} Z"/>`;
+     const footK=[['grass',150,210],['frond',150,220],['flax',150,214],['toetoe',150,206]], fr=rng(sub(14)), fpick=kindPicker(fr,footK);
+     for(const fx of [372,452,600,748,828]){ if(fr()<0.9){ const [kn,a,b]=fpick(), h=a+(b-a)*fr();
+       mfore += STAMP[kn].draw(fx+(fr()-0.5)*30, mcY(fx)+6, h, 'var(--fore)', (sub(14)^(fx*7))|0, fx<600?-1:1); } }}
+    const kS=2.3; mfore += kiwi(296, FLOOR-58, kS, 'var(--fore)');
     $('l-fore').innerHTML=mfore;
   }
 

--- a/index.html
+++ b/index.html
@@ -174,6 +174,10 @@
     .edge{display:block;width:25vw}
     .intro,.content{padding-left:26vw;padding-right:26vw}
     .intro h1{font-size:clamp(2.1rem,9vw,4.8rem)}
+    /* lift the © line up into the open clearing so it floats ABOVE the dense forest-floor
+       foliage at the very bottom (which sits in front of it), instead of hiding behind it. */
+    .content{padding-bottom:12vh}
+    footer{padding-bottom:27vh}
   }
 </style>
 </head>
@@ -916,7 +920,7 @@
     // 378..822, plus a little extra clamp pad so a stray crown tip never reaches the copy. Flax
     // gets extra room because it leans inward (below), so its tilted fronds still clear the text.
     const MCL=362, MCR=838, TOP_M=34;
-    const mclampX=(x,h,kn,side)=>{ const w=((STAMP[kn].cw||0.5)+(kn==='flax'?0.18:0))*h+8;
+    const mclampX=(x,h,kn,side)=>{ const w=((STAMP[kn].cw||0.5)+(kn==='flax'?0.18:kn==='nikau'?0.18:0))*h+8;
       return side<0 ? Math.min(x,MCL-w) : Math.max(x,MCR+w); };
 
     // a TALL hillside bank up one margin: ground rises from the centre-floor to the frame edge,
@@ -952,8 +956,10 @@
       items.sort((p,q)=>q.h-p.h);
       for(const it of items){
         let s=STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,side);
-        // lean harakeke/flax inward toward the clearing for a softer, more natural framing
-        if(it.kn==='flax') s=`<g transform="rotate(${(-side*12)} ${it.x.toFixed(1)} ${it.by.toFixed(1)})">${s}</g>`;
+        // lean harakeke/flax inward (softer framing); give the tall nīkau palm a gentle inward
+        // lean too so its shuttlecock crown reads with character instead of a straight hidden trunk.
+        const tilt = it.kn==='flax' ? 12 : it.kn==='nikau' ? 6+(it.sd&3)*1.2 : 0;
+        if(tilt) s=`<g transform="rotate(${(-side*tilt).toFixed(1)} ${it.x.toFixed(1)} ${it.by.toFixed(1)})">${s}</g>`;
         g+=s;
       }
       return g;
@@ -968,10 +974,12 @@
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
     const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344]];
 
-    $('l-far').innerHTML    = tallBay(-1,360,182,kFar,'var(--far)',sub(8),86,1.5)    + tallBay(+1,840,182,kFar,'var(--far)',sub(9),86,1.5);
-    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),126,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),126,1.5);
-    $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),220,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),220,1.6);
-    $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),200,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),200,1.7);
+    // vstep spaces the big trees apart — eased a touch so the far→margin walls don't crowd with
+    // large trunks (footer density comes from the small-treeline mounds below instead).
+    $('l-far').innerHTML    = tallBay(-1,360,182,kFar,'var(--far)',sub(8),118,1.5)   + tallBay(+1,840,182,kFar,'var(--far)',sub(9),118,1.5);
+    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),164,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),164,1.5);
+    $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),272,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),272,1.6);
+    $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),248,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),248,1.7);
     let mfore = tallBay(-1,228,366,kFore,'var(--fore)',sub(5),250,1.8)+tallBay(+1,972,366,kFore,'var(--fore)',sub(6),250,1.8);
 
     // STACKED valley-floor mounds (receding light→dark, as on desktop): a low light mound per back
@@ -982,10 +990,11 @@
       const x0=cx-wd*2.3, x1=cx+wd*2.3; let d=`M${x0.toFixed(0)},${MOB_H+8}`;
       for(let i=0;i<=48;i++){const x=x0+(x1-x0)*i/48; d+=` L${x.toFixed(1)},${cY(x).toFixed(1)}`;}
       let h=`<path fill="${fill}" d="${d} L${x1.toFixed(0)},${MOB_H+8} Z"/>`;
-      const mbKinds=[['ponga',46,86],['nikau',50,92],['cabbage',48,88],['pohutukawa',44,80],['flax',38,68]], pick=kindPicker(r,mbKinds);
-      for(const fx of [332,420,508,596,684,772,860]){ if(fx>x0&&fx<x1&&r()<0.82){
-        const [kn,a,b]=pick(), ph=(a+(b-a)*r())*hMul, jx=fx+(r()-0.5)*30;
-        h+=STAMP[kn].draw(jx, cY(jx)+(kn==='flax'?34:6), ph, fill, (seed^(fx*7))|0, fx<596?-1:1); } }
+      const mbKinds=[['ponga',46,86],['cabbage',48,88],['pohutukawa',44,80],['flax',38,68],['toetoe',40,72]], pick=kindPicker(r,mbKinds);
+      // dense small treeline right across the mound (two passes) — packs the footer back layers.
+      for(let pass=0;pass<2;pass++) for(let fx=304+pass*19;fx<=888;fx+=34){ if(fx>x0&&fx<x1&&r()<0.9){
+        const [kn,a,b]=pick(), ph=(a+(b-a)*r())*hMul, jx=fx+(r()-0.5)*26;
+        h+=STAMP[kn].draw(jx, cY(jx)+(kn==='flax'?34:6), ph, fill, (seed^((fx*7+pass*1009)|0))|0, fx<596?-1:1); } }
       $(layer).innerHTML += h;
     };
     moundBand('l-far',   206,'var(--far)',   sub(31),0.8);

--- a/index.html
+++ b/index.html
@@ -968,7 +968,9 @@
     // back→front: smaller + reaching closer to the centre behind, bolder + further out in front.
     // NOTE: no lone `frond` in the airy far/mid layers — a single frond against the light reads as
     // a floating leaf (it has no clustered base). Fronds live only in the dense foreground thicket.
-    const kFar=[['ponga',150,250],['nikau',160,270],['pohutukawa',140,236],['cabbage',146,244],['flax',120,200],['toetoe',124,204]];
+    // pōhutukawa (big heavy crimson crown) thinned across the mobile diorama: dropped from the far
+    // wall + the footer mounds, kept only in mid/bush so it still appears, just less often.
+    const kFar=[['ponga',150,250],['nikau',160,270],['cabbage',146,244],['flax',120,200],['toetoe',124,204]];
     const kMid=[['ponga',230,360],['nikau',248,392],['pohutukawa',210,340],['cabbage',220,352],['flax',186,300]];
     const kBush=[['ponga',330,500],['nikau',380,560],['pohutukawa',300,452],['cabbage',312,470]];
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
@@ -990,11 +992,11 @@
       const x0=cx-wd*2.3, x1=cx+wd*2.3; let d=`M${x0.toFixed(0)},${MOB_H+8}`;
       for(let i=0;i<=48;i++){const x=x0+(x1-x0)*i/48; d+=` L${x.toFixed(1)},${cY(x).toFixed(1)}`;}
       let h=`<path fill="${fill}" d="${d} L${x1.toFixed(0)},${MOB_H+8} Z"/>`;
-      const mbKinds=[['ponga',46,86],['cabbage',48,88],['pohutukawa',44,80],['flax',38,68],['toetoe',40,72]], pick=kindPicker(r,mbKinds);
-      // dense small treeline right across the mound (two passes) — packs the footer back layers.
-      for(let pass=0;pass<2;pass++) for(let fx=304+pass*19;fx<=888;fx+=34){ if(fx>x0&&fx<x1&&r()<0.9){
-        const [kn,a,b]=pick(), ph=(a+(b-a)*r())*hMul, jx=fx+(r()-0.5)*26;
-        h+=STAMP[kn].draw(jx, cY(jx)+(kn==='flax'?34:6), ph, fill, (seed^((fx*7+pass*1009)|0))|0, fx<596?-1:1); } }
+      const mbKinds=[['ponga',46,86],['cabbage',48,88],['flax',38,68],['toetoe',40,72]], pick=kindPicker(r,mbKinds);
+      // a small treeline across the mound — packs the footer back layers (kept moderate).
+      for(let fx=312;fx<=884;fx+=42){ if(fx>x0&&fx<x1&&r()<0.78){
+        const [kn,a,b]=pick(), ph=(a+(b-a)*r())*hMul, jx=fx+(r()-0.5)*28;
+        h+=STAMP[kn].draw(jx, cY(jx)+(kn==='flax'?34:6), ph, fill, (seed^((fx*7)|0))|0, fx<596?-1:1); } }
       $(layer).innerHTML += h;
     };
     moundBand('l-far',   206,'var(--far)',   sub(31),0.8);

--- a/index.html
+++ b/index.html
@@ -968,11 +968,30 @@
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
     const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344]];
 
-    $('l-far').innerHTML    = tallBay(-1,360,182,kFar,'var(--far)',sub(8),100,1.5)   + tallBay(+1,840,182,kFar,'var(--far)',sub(9),100,1.5);
-    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),150,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),150,1.5);
+    $('l-far').innerHTML    = tallBay(-1,360,182,kFar,'var(--far)',sub(8),86,1.5)    + tallBay(+1,840,182,kFar,'var(--far)',sub(9),86,1.5);
+    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),126,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),126,1.5);
     $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),220,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),220,1.6);
     $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),200,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),200,1.7);
     let mfore = tallBay(-1,228,366,kFore,'var(--fore)',sub(5),250,1.8)+tallBay(+1,972,366,kFore,'var(--fore)',sub(6),250,1.8);
+
+    // STACKED valley-floor mounds (receding light→dark, as on desktop): a low light mound per back
+    // layer peeking up behind the dark fore mound — adds back-layer density across the footer and
+    // the bottom of the margins. Kept low (peaks well under the footer copy) with small treeline.
+    const moundBand=(layer,amp,fill,seed,hMul)=>{
+      const r=rng(seed), cx=596, wd=300, nz=noise(r,16), cY=x=>FLOOR-amp*Math.exp(-Math.pow((x-cx)/wd,2))+nz((x-300)/600)*0.5;
+      const x0=cx-wd*2.3, x1=cx+wd*2.3; let d=`M${x0.toFixed(0)},${MOB_H+8}`;
+      for(let i=0;i<=48;i++){const x=x0+(x1-x0)*i/48; d+=` L${x.toFixed(1)},${cY(x).toFixed(1)}`;}
+      let h=`<path fill="${fill}" d="${d} L${x1.toFixed(0)},${MOB_H+8} Z"/>`;
+      const mbKinds=[['ponga',46,86],['nikau',50,92],['cabbage',48,88],['pohutukawa',44,80],['flax',38,68]], pick=kindPicker(r,mbKinds);
+      for(const fx of [332,420,508,596,684,772,860]){ if(fx>x0&&fx<x1&&r()<0.82){
+        const [kn,a,b]=pick(), ph=(a+(b-a)*r())*hMul, jx=fx+(r()-0.5)*30;
+        h+=STAMP[kn].draw(jx, cY(jx)+(kn==='flax'?34:6), ph, fill, (seed^(fx*7))|0, fx<596?-1:1); } }
+      $(layer).innerHTML += h;
+    };
+    moundBand('l-far',   206,'var(--far)',   sub(31),0.8);
+    moundBand('l-mid',   172,'var(--mid)',   sub(32),1.0);
+    moundBand('l-bush',  144,'var(--bush)',  sub(33),1.25);
+    moundBand('l-margin',122,'var(--margin)',sub(34),1.45);
 
     // valley floor: a low central mound closing the foot of the clearing (connected to the base),
     // a small foreground thicket on it, then the focal kiwi — placed where the dark fore/margin/

--- a/index.html
+++ b/index.html
@@ -174,10 +174,6 @@
     .edge{display:block;width:25vw}
     .intro,.content{padding-left:26vw;padding-right:26vw}
     .intro h1{font-size:clamp(2.1rem,9vw,4.8rem)}
-    /* lift the © line up into the open clearing so it floats ABOVE the dense forest-floor
-       foliage at the very bottom (which sits in front of it), instead of hiding behind it. */
-    .content{padding-bottom:12vh}
-    footer{padding-bottom:27vh}
   }
 </style>
 </head>
@@ -211,7 +207,6 @@
   </ul></section>
 </main>
 
-<footer>© <span id="year"></span> Alec Sharp</footer>
 
 <div class="stage stage-front">
   <div class="layer" data-depth="0.40"><svg id="l-margin" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice" aria-hidden="true"></svg></div>
@@ -244,7 +239,6 @@
 
 <script src="js/stamps.js"></script>
 <script>
-  document.getElementById('year').textContent = new Date().getFullYear();
   const $=id=>document.getElementById(id);
 
   /* =====================================================================

--- a/index.html
+++ b/index.html
@@ -925,7 +925,7 @@
       let g=`<path fill="${fill}" d="${d}"/>`, items=[], pick=kindPicker(r,kinds);
       // place plants both by VERTICAL change (fills the steep dive) AND by HORIZONTAL spacing
       // (fills the high plateau that flanks the hero) — so foliage covers the whole visible margin.
-      const xstep=Math.abs(span)*0.10;
+      const xstep=Math.abs(span)*0.082;
       let lastY=crest(edge)+vstep*3, lastX=edge-xstep*3;
       for(let i=0;i<=240;i++){
         const x=edge+span*(i/240), cy=crest(x);
@@ -948,9 +948,9 @@
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
     const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344],['grass',150,232]];
 
-    $('l-far').innerHTML    = tallBay(-1,372,182,kFar,'var(--far)',sub(8),112,1.5)   + tallBay(+1,828,182,kFar,'var(--far)',sub(9),112,1.5);
-    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),170,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),170,1.5);
-    $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),250,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),250,1.6);
+    $('l-far').innerHTML    = tallBay(-1,372,182,kFar,'var(--far)',sub(8),100,1.5)   + tallBay(+1,828,182,kFar,'var(--far)',sub(9),100,1.5);
+    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),150,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),150,1.5);
+    $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),220,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),220,1.6);
     $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),200,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),200,1.7);
     let mfore = tallBay(-1,228,366,kFore,'var(--fore)',sub(5),250,1.8)+tallBay(+1,972,366,kFore,'var(--fore)',sub(6),250,1.8);
 

--- a/index.html
+++ b/index.html
@@ -923,11 +923,14 @@
       for(let i=1;i<=N;i++){const x=edge+span*(i/N); d+=` L${x.toFixed(1)},${crest(x).toFixed(1)}`;}
       d+=` L${innerX.toFixed(1)},${MOB_H+8} Z`;
       let g=`<path fill="${fill}" d="${d}"/>`, items=[], pick=kindPicker(r,kinds);
-      let lastY=crest(edge)+vstep*3;
+      // place plants both by VERTICAL change (fills the steep dive) AND by HORIZONTAL spacing
+      // (fills the high plateau that flanks the hero) — so foliage covers the whole visible margin.
+      const xstep=Math.abs(span)*0.10;
+      let lastY=crest(edge)+vstep*3, lastX=edge-xstep*3;
       for(let i=0;i<=240;i++){
         const x=edge+span*(i/240), cy=crest(x);
-        if(Math.abs(cy-lastY)>=vstep*(0.78+0.44*r())){
-          lastY=cy;
+        if(Math.abs(cy-lastY)>=vstep*(0.78+0.44*r()) || Math.abs(x-lastX)>=xstep*(0.8+0.5*r())){
+          lastY=cy; lastX=x;
           const t=Math.max(0,Math.min(1,(cy-edgeY)/(FLOOR-edgeY)));   // 0 near top → 1 at the floor
           const [kn,a,b]=pick(); const h=(a+(b-a)*r())*(0.76+0.24*t); // bolder toward the floor, still tall up top
           items.push({x:clampX(x,h,kn,side),by:cy+10,h,kn,sd:(seed^(i*61))|0});
@@ -945,11 +948,11 @@
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
     const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344],['grass',150,232]];
 
-    $('l-far').innerHTML    = tallBay(-1,372,200,kFar,'var(--far)',sub(8),112,1.0)   + tallBay(+1,828,200,kFar,'var(--far)',sub(9),112,1.0);
-    $('l-mid').innerHTML    = tallBay(-1,338,232,kMid,'var(--mid)',sub(10),170,1.0)  + tallBay(+1,862,232,kMid,'var(--mid)',sub(11),170,1.0);
-    $('l-bush').innerHTML   = tallBay(-1,304,272,kBush,'var(--bush)',sub(1),250,1.0) + tallBay(+1,896,272,kBush,'var(--bush)',sub(2),250,1.0);
-    $('l-margin').innerHTML = tallBay(-1,266,322,kMargin,'var(--margin)',sub(3),200,1.0)+tallBay(+1,934,322,kMargin,'var(--margin)',sub(4),200,1.0);
-    let mfore = tallBay(-1,228,384,kFore,'var(--fore)',sub(5),250,1.0)+tallBay(+1,972,384,kFore,'var(--fore)',sub(6),250,1.0);
+    $('l-far').innerHTML    = tallBay(-1,372,182,kFar,'var(--far)',sub(8),112,1.5)   + tallBay(+1,828,182,kFar,'var(--far)',sub(9),112,1.5);
+    $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),170,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),170,1.5);
+    $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),250,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),250,1.6);
+    $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),200,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),200,1.7);
+    let mfore = tallBay(-1,228,366,kFore,'var(--fore)',sub(5),250,1.8)+tallBay(+1,972,366,kFore,'var(--fore)',sub(6),250,1.8);
 
     // valley floor: a low central mound closing the foot of the clearing (connected to the base),
     // a small foreground thicket on it, then the focal kiwi facing right into the clearing (as desktop).

--- a/index.html
+++ b/index.html
@@ -909,8 +909,15 @@
       html+=items.map(it=>STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,it.x<600?-1:1)).join('');
       return html;
     };
-    $('l-haze').innerHTML=tallBand(250,[['pohutukawa',22,34],['cabbage',24,38],['ponga',24,38],['nikau',26,40],['flax',18,30],['grass',11,18]],50,'var(--haze)',sub(21),12);
-    $('l-deep').innerHTML=tallBand(322,[['pohutukawa',30,48],['cabbage',32,50],['ponga',32,50],['nikau',34,52],['flax',24,40],['grass',15,25]],40,'var(--deep)',sub(19),14);
+    $('l-haze').innerHTML=tallBand(250,[['pohutukawa',22,34],['cabbage',24,38],['ponga',24,38],['nikau',26,40],['flax',18,30]],50,'var(--haze)',sub(21),12);
+    $('l-deep').innerHTML=tallBand(322,[['pohutukawa',30,48],['cabbage',32,50],['ponga',32,50],['nikau',34,52],['flax',24,40]],40,'var(--deep)',sub(19),14);
+
+    // WIDENED central clearing for mobile — more breathing room for the text than desktop's
+    // 378..822, plus a little extra clamp pad so a stray crown tip never reaches the copy. Flax
+    // gets extra room because it leans inward (below), so its tilted fronds still clear the text.
+    const MCL=362, MCR=838, TOP_M=34;
+    const mclampX=(x,h,kn,side)=>{ const w=((STAMP[kn].cw||0.5)+(kn==='flax'?0.18:0))*h+8;
+      return side<0 ? Math.min(x,MCL-w) : Math.max(x,MCR+w); };
 
     // a TALL hillside bank up one margin: ground rises from the centre-floor to the frame edge,
     // plants rooted ON the crest with their feet buried in the bank — one connected sheet, never
@@ -932,12 +939,19 @@
         if(Math.abs(cy-lastY)>=vstep*(0.78+0.44*r()) || Math.abs(x-lastX)>=xstep*(0.8+0.5*r())){
           lastY=cy; lastX=x;
           const t=Math.max(0,Math.min(1,(cy-edgeY)/(FLOOR-edgeY)));   // 0 near top → 1 at the floor
-          const [kn,a,b]=pick(); const h=(a+(b-a)*r())*(0.76+0.24*t); // bolder toward the floor, still tall up top
-          items.push({x:clampX(x,h,kn,side),by:cy+10,h,kn,sd:(seed^(i*61))|0});
+          const [kn,a,b]=pick(); let h=(a+(b-a)*r())*(0.76+0.24*t);   // bolder toward the floor, still tall up top
+          const px=mclampX(x,h,kn,side), by=crest(px)+10;             // ROOT on the bank at the clamped x → never floats
+          h=Math.min(h,(by-TOP_M)/(STAMP[kn].crown||1.1));            // cap height so crowns never clip the frame top
+          items.push({x:px,by,h,kn,sd:(seed^(i*61))|0});
         }
       }
       items.sort((p,q)=>q.h-p.h);
-      for(const it of items) g+=STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,side);
+      for(const it of items){
+        let s=STAMP[it.kn].draw(it.x,it.by,it.h,fill,it.sd,side);
+        // lean harakeke/flax inward toward the clearing for a softer, more natural framing
+        if(it.kn==='flax') s=`<g transform="rotate(${(-side*12)} ${it.x.toFixed(1)} ${it.by.toFixed(1)})">${s}</g>`;
+        g+=s;
+      }
       return g;
     };
 
@@ -946,29 +960,33 @@
     const kMid=[['ponga',230,360],['nikau',248,392],['pohutukawa',210,340],['cabbage',220,352],['flax',186,300],['frond',182,292]];
     const kBush=[['ponga',330,500],['nikau',380,560],['pohutukawa',300,452],['cabbage',312,470]];
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
-    const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344],['grass',150,232]];
+    const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344]];
 
-    $('l-far').innerHTML    = tallBay(-1,372,182,kFar,'var(--far)',sub(8),100,1.5)   + tallBay(+1,828,182,kFar,'var(--far)',sub(9),100,1.5);
+    $('l-far').innerHTML    = tallBay(-1,360,182,kFar,'var(--far)',sub(8),100,1.5)   + tallBay(+1,840,182,kFar,'var(--far)',sub(9),100,1.5);
     $('l-mid').innerHTML    = tallBay(-1,338,214,kMid,'var(--mid)',sub(10),150,1.5)  + tallBay(+1,862,214,kMid,'var(--mid)',sub(11),150,1.5);
     $('l-bush').innerHTML   = tallBay(-1,304,254,kBush,'var(--bush)',sub(1),220,1.6) + tallBay(+1,896,254,kBush,'var(--bush)',sub(2),220,1.6);
     $('l-margin').innerHTML = tallBay(-1,266,304,kMargin,'var(--margin)',sub(3),200,1.7)+tallBay(+1,934,304,kMargin,'var(--margin)',sub(4),200,1.7);
     let mfore = tallBay(-1,228,366,kFore,'var(--fore)',sub(5),250,1.8)+tallBay(+1,972,366,kFore,'var(--fore)',sub(6),250,1.8);
 
     // valley floor: a low central mound closing the foot of the clearing (connected to the base),
-    // a small foreground thicket on it, then the focal kiwi facing right into the clearing (as desktop).
-    {const r=rng(sub(13)), amp=140, mcY=x=>FLOOR-amp*Math.exp(-Math.pow((x-600)/250,2))+noise(r,18)((x-300)/600)*0.6;
+    // a small foreground thicket on it, then the focal kiwi — placed where the dark fore/margin/
+    // bush have dived away so its silhouette reads against the LIGHTER far/deep backdrop (as desktop).
+    {const r=rng(sub(13)), amp=108, mcY=x=>FLOOR-amp*Math.exp(-Math.pow((x-560)/270,2))+noise(r,18)((x-300)/600)*0.6;
      let md=`M280,${MOB_H+8}`;
      for(let i=0;i<=44;i++){const x=280+640*i/44; md+=` L${x.toFixed(1)},${mcY(x).toFixed(1)}`;}
      mfore += `<path fill="var(--fore)" d="${md} L920,${MOB_H+8} Z"/>`;
-     const footK=[['grass',150,210],['frond',150,220],['flax',150,214],['toetoe',150,206]], fr=rng(sub(14)), fpick=kindPicker(fr,footK);
-     for(const fx of [372,452,600,748,828]){ if(fr()<0.9){ const [kn,a,b]=fpick(), h=a+(b-a)*fr();
-       mfore += STAMP[kn].draw(fx+(fr()-0.5)*30, mcY(fx)+6, h, 'var(--fore)', (sub(14)^(fx*7))|0, fx<600?-1:1); } }}
-    const kS=2.3; mfore += kiwi(296, FLOOR-58, kS, 'var(--fore)');
-    // two pīwakawaka perched together on a foreground twig on the RIGHT, facing each other
-    // (the right bird is the same stamp mirrored about its own centre) — echoing desktop.
-    mfore += limb([[968,FLOOR-150],[952,FLOOR-84],[946,FLOOR-16],[946,MOB_H+8]],[2,5,9,12],'var(--fore)',true);
-    {const ftS=1.85, ftL=872, ftR=934, ftCy=FLOOR-172;
-     mfore += limb([[ftL-12,ftCy+30],[ftL+30,ftCy+58],[ftL+86,ftCy+86],[ftR+44,ftCy+150]],[1.2,3.5,6,9],'var(--fore)',true);
+     // foreground thicket kept to the centre-RIGHT, leaving a clear pocket for the kiwi on the left.
+     const footK=[['frond',150,220],['flax',150,214],['toetoe',150,206]], fr=rng(sub(14)), fpick=kindPicker(fr,footK);
+     for(const fx of [528,612,694,778]){ if(fr()<0.85){ const [kn,a,b]=fpick(), h=a+(b-a)*fr();
+       mfore += STAMP[kn].draw(fx+(fr()-0.5)*24, mcY(fx)+6, h, 'var(--fore)', (sub(14)^(fx*7))|0, fx<600?-1:1); } }
+     // FOCAL KIWI — on the low mound just inside the clearing, head & bill facing right into OPEN
+     // deep (clear pocket to ~520), feet buried in the mound; its silhouette reads against the light.
+     const kS=2.2, kx=372; mfore += kiwi(kx, mcY(kx)-47*kS, kS, 'var(--fore)');}
+    // two pīwakawaka on a twig on the RIGHT, set where bush/margin/fore have dived away so they
+    // read against the lighter far/deep backdrop; the twig roots to the base (connected sheet).
+    {const ftS=1.9, ftL=876, ftR=920, ftCy=FLOOR-374;
+     mfore += limb([[ftR+30,ftCy+34],[ftR+26,ftCy+150],[ftR+20,ftCy+320],[ftR+16,MOB_H+8]],[2,5,9,13],'var(--fore)',true)
+            + limb([[ftL-10,ftCy+26],[ftL+34,ftCy+52],[ftL+88,ftCy+80],[ftR+30,ftCy+34]],[1,3.2,5.5,7],'var(--fore)',true);
      mfore += fantail(ftL, ftCy, ftS, 'var(--fore)')
             + `<g transform="translate(${(2*ftR).toFixed(1)} 0) scale(-1 1)">`+fantail(ftR, ftCy+6, ftS, 'var(--fore)')+`</g>`;}
     $('l-fore').innerHTML=mfore;

--- a/index.html
+++ b/index.html
@@ -886,9 +886,9 @@
       $('l-'+k).setAttribute('viewBox',`0 0 1200 ${MOB_H}`);
 
     // SKY strip + moon hole + a drifting skein, all kept high & clear of the text (RULES §3,§4).
-    let cut=`<rect width="1200" height="${MOB_H}" fill="#fff"/><circle cx="600" cy="140" r="48" fill="#000"/>`;
+    let cut=`<rect width="1200" height="${MOB_H}" fill="#fff"/><circle cx="392" cy="150" r="46" fill="#000"/>`;
     {const r=rng(sub(20));
-     for(const [bx,by,bw] of [[486,206,22],[556,180,26],[636,168,30],[716,184,24],[600,232,17]])
+     for(const [bx,by,bw] of [[560,196,22],[636,172,27],[716,160,30],[792,178,24],[690,224,17]])
        cut+=birdHole(bx+(r()-0.5)*24, by+(r()-0.5)*14, bw, (r()-0.5)*0.5);}
     $('l-sky').innerHTML=
       `<defs><mask id="cut-sky-m" maskUnits="userSpaceOnUse" x="0" y="0" width="1200" height="${MOB_H}">${cut}</mask></defs>`+
@@ -945,11 +945,11 @@
     const kMargin=[['ponga',260,392],['cabbage',262,396],['flax',214,326],['toetoe',214,318],['frond',224,338]];
     const kFore=[['frond',280,420],['flax',236,352],['toetoe',236,344],['grass',150,232]];
 
-    $('l-far').innerHTML    = tallBay(-1,372,210,kFar,'var(--far)',sub(8),130,1.0)   + tallBay(+1,828,210,kFar,'var(--far)',sub(9),130,1.0);
-    $('l-mid').innerHTML    = tallBay(-1,338,240,kMid,'var(--mid)',sub(10),195,1.0)  + tallBay(+1,862,240,kMid,'var(--mid)',sub(11),195,1.0);
-    $('l-bush').innerHTML   = tallBay(-1,304,280,kBush,'var(--bush)',sub(1),290,1.0) + tallBay(+1,896,280,kBush,'var(--bush)',sub(2),290,1.0);
-    $('l-margin').innerHTML = tallBay(-1,266,330,kMargin,'var(--margin)',sub(3),235,1.0)+tallBay(+1,934,330,kMargin,'var(--margin)',sub(4),235,1.0);
-    let mfore = tallBay(-1,228,390,kFore,'var(--fore)',sub(5),285,1.0)+tallBay(+1,972,390,kFore,'var(--fore)',sub(6),285,1.0);
+    $('l-far').innerHTML    = tallBay(-1,372,200,kFar,'var(--far)',sub(8),112,1.0)   + tallBay(+1,828,200,kFar,'var(--far)',sub(9),112,1.0);
+    $('l-mid').innerHTML    = tallBay(-1,338,232,kMid,'var(--mid)',sub(10),170,1.0)  + tallBay(+1,862,232,kMid,'var(--mid)',sub(11),170,1.0);
+    $('l-bush').innerHTML   = tallBay(-1,304,272,kBush,'var(--bush)',sub(1),250,1.0) + tallBay(+1,896,272,kBush,'var(--bush)',sub(2),250,1.0);
+    $('l-margin').innerHTML = tallBay(-1,266,322,kMargin,'var(--margin)',sub(3),200,1.0)+tallBay(+1,934,322,kMargin,'var(--margin)',sub(4),200,1.0);
+    let mfore = tallBay(-1,228,384,kFore,'var(--fore)',sub(5),250,1.0)+tallBay(+1,972,384,kFore,'var(--fore)',sub(6),250,1.0);
 
     // valley floor: a low central mound closing the foot of the clearing (connected to the base),
     // a small foreground thicket on it, then the focal kiwi facing right into the clearing (as desktop).


### PR DESCRIPTION
## What

A portrait-native **forest-canyon** layout for the homepage diorama on phones. The wide 1200×800 (3:2) desktop scene can't be cropped into anything lush on a portrait screen — `cover` only shows the empty central clearing, and fit-width shrinks the foliage to a thin strip. So mobile gets its own composition built from the same paper-cut stamps, arranged tall.

Everything is inside an `if(MB)` (`max-width:760px`) block that overwrites the layers after the desktop build, so **the desktop scene is unchanged** apart from the copyright removal (below).

## Highlights
- **Forest canyon**: dense foliage walls up both margins on tapered hillside banks, plants rooted on the crest (connected sheets — no floaters, RULES §6), diving from a clear central text column (§7b).
- Full-width haze/deep back bands (deep = the flat card the text reads on), sky + moon + bird-holes up top.
- Stacked receding valley-floor mounds for back-layer footer depth; focal **kiwi** and spaced **pīwakawaka** (fantails) silhouetted against the lighter layers.
- nīkau lean, flax tucked/buried, pōhutukawa thinned, generous text clearing.
- Replaces the old side-frame "3-panel" mobile columns; also removes the aurora-only feather (cut-paper north star) and fixes the Safari URL-bar resize jump.
- **Dropped the `©` footer line** site-wide (desktop + mobile).

## Verification
Screenshot-verified across top/mid/bottom scroll, totara + aurora palettes, 360px + 390px widths, and several procedural seeds (no floaters; kiwi/fantails read; text clears foliage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)